### PR TITLE
Form data persistence

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -64,3 +64,4 @@ de:
   positive: "Positiv"
   negative: "Negativ"
   dataProtection: "Datenschutz"
+  saveResponses: "Erinnere dich an meine Antworten für das nächste Mal."

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -8,6 +8,10 @@ de:
   <p><b>Egal ob Sie krank sind oder gesund, infiziert oder nicht: Ihre Daten können helfen, Leben zu retten.</b> Wenn Sie das untenstehende Formular ausfüllen, tragen Sie dazu bei, dass wir diese Krise gemeinsam meistern können.  Im Idealfall wiederholen Sie Ihre Teilnahme im Wochentakt (<a href=\"/images/covidtracker.ics\">Kalendererinnerung einrichten</a>).</p>
   <p>Wichtig: Wir verwenden die erfassten Daten nicht, um Rückschlüsse auf einzelne Personen zu ziehen.</p>"
   toform: "Zum Formular"
+  firstTimeForm: "Füllen Sie dieses Formular zum ersten Mal aus?"
+  participantCode: "(Optional) Ihr Teilnahmecode"
+  manualParticipantCode: "(Optional) Geben Sie Ihren Teilnahmecode ein"
+  unlistedCode: "Mein Code ist nicht aufgeführt"
   sex: "Geschlecht"
   male: "Männlich"
   female: "Weiblich"
@@ -65,3 +69,5 @@ de:
   negative: "Negativ"
   dataProtection: "Datenschutz"
   saveResponses: "Erinnere dich an meine Antworten für das nächste Mal."
+  cookieWarning: "Wenn Sie 'Ja' auswählen, stimmen Sie der Verwendung von Cookies zu. Wenn Sie Cookies verwenden, können andere Benutzer, die Zugriff auf diesen Computer haben, möglicherweise die Antworten auf die Umfrage abrufen."
+  consentToStudy: "Ich stimme den <a href=\"/de/consent.html\" target=\"_blank\"> Teilnahmebedingungen </a> für diese Studie zu."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -15,7 +15,7 @@ en:
   age: "Age"
   birthyear: "Year of Birth"
   zip: "Postal code"
-  other: "other"
+  other: "Other"
   phoneDigits: "Last four digits of your phone number"
   feelsHealthy: "To the best of your knowledge right now, do you feel healthy?"
   hasBeenTested: "Have you been tested for COVID-19?"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,6 +8,10 @@ en:
   <p><b>Whether you are sick or healthy, infected or not, your data can help save lives.</b> By filling out the form below, you are helping us to overcome this crisis together. Ideally, repeat your participation weekly (<a href=\"/images/covidtracker.ics\">set up calendar event</a>).</p>
   <p>Important: The data is collected anonymously and does not allow identification of individuals.</p>"
   toform: "Submit your feedback"
+  firstTimeForm: "Is this your first time filling out this form?"
+  participantCode: "(Optional) Your participation code from before"
+  manualParticipantCode: "(Optional) Enter your participation code"
+  unlistedCode: "My code isn't listed"
   sex: "Sex"
   male: "Male"
   female: "Female"
@@ -64,3 +68,5 @@ en:
   negative: "Negative"
   dataProtection: "Data protection"
   saveResponses: "Remember my responses for next time"
+  cookieWarning: "If you select 'yes', you are consenting to using cookies. When using cookies, other users who have access to this computer may be able to retrieve the answers to the survey."
+  consentToStudy: "I consent to the <a href=\"/en/consent.html\" target=\"_blank\">terms of participation</a> in this study"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -63,3 +63,4 @@ en:
   positive: "Positive"
   negative: "Negative"
   dataProtection: "Data protection"
+  saveResponses: "Remember my responses for next time"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -8,6 +8,10 @@
     <p><b>Que vous soyez malade ou en bonne santé, infecté-e ou non : Vos données peuvent aider à sauver des vies.</b> En remplissant le formulaire ci-dessous, vous participez à l’effort commun pour venir à bout de cette crise. L’idéal serait que vous renouveliez votre participation chaque semaine.</p>
     <p>Important: les données récoltées sont anonyme et ne peuvent pas être associées à des personnes.</p>"
     toform: "Vers le formulaire"
+    firstTimeForm: "C'est la première fois que vous remplissez ce formulaire?"
+    participantCode: "(Optionnel) Votre code de participation d'avant"
+    manualParticipantCode: "(Optionnel) Entrez votre code de participation"
+    unlistedCode: "Mon code n'est pas répertorié"
     sex: "Sexe"
     male: "Homme"
     female: "Femme"
@@ -65,3 +69,5 @@
     negative: "Négatif"
     dataProtection: "Protection des données"
     saveResponses: "Rappelez-vous mes réponses pour la prochaine fois."
+    cookieWarning: "Si vous sélectionnez 'oui', vous consentez à l'utilisation de cookies. Lors de l'utilisation de cookies, d'autres utilisateurs qui ont accès à cet ordinateur peuvent être en mesure de récupérer les réponses à l'enquête."
+    consentToStudy: "J'accepte les <a href=\"/fr/consent.html\" target=\"_blank\"> conditions de participation </a> à cette étude"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -64,3 +64,4 @@
     positive: "Positif"
     negative: "Négatif"
     dataProtection: "Protection des données"
+    saveResponses: "Rappelez-vous mes réponses pour la prochaine fois."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -8,6 +8,10 @@
     <p><b>Indipendentemente dal fatto che sia sano o ammalato, che sia infetto o meno: I suoi dati possono contribuire a salvare vite umane.</b> Con la compilazione del modulo sottostante, può fornire il suo contributo, affinché possiamo superare insieme questa crisi. L’ideale sarebbe poter partecipare a cadenza settimanale.</p>
     <p>Importante: il rilevamento dei dati garantisce l’anonimato e non consente di trarre conclusioni sulla sua identità.</p>"
     toform: "Al modulo"
+    firstTimeForm: "È la prima volta che compili questo modulo?"
+    participantCode: "(Opzionale) Il codice di partecipazione di prima"
+    manualParticipantCode: "(Opzionale) Inserisci il tuo codice di partecipazione"
+    unlistedCode: "Il mio codice non è elencato"
     sex: "Sesso"
     male: "Uomo"
     female: "Donna"
@@ -65,3 +69,5 @@
     negative: "Negativo"
     dataProtection: "Protezione dei dati"
     saveResponses: "Ricorda le mie risposte per la prossima volta."
+    cookieWarning: "Se si seleziona 'sì', si acconsente all'utilizzo dei cookie. Quando si utilizzano i cookie, altri utenti che hanno accesso a questo computer potrebbero essere in grado di recuperare le risposte al sondaggio."
+    consentToStudy: "Acconsento ai <a href=\"/it/consent.html\" target=\"_blank\"> termini di partecipazione </a> in questo studio"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -64,3 +64,4 @@
     positive: "Positivo"
     negative: "Negativo"
     dataProtection: "Protezione dei dati"
+    saveResponses: "Ricorda le mie risposte per la prossima volta."

--- a/source/javascripts/persistence.js
+++ b/source/javascripts/persistence.js
@@ -1,0 +1,219 @@
+
+// marks new form data entries that don't yet have a server-generated code
+var REPLACE_SENTINEL = '__replace-me__';
+
+// ---------------------------------------------------------------------------------------------
+// --- form data store manipulation
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Replaces keys marked 'oldCode' with 'newCode' in the form data store.
+ * @param oldCode the code to replace
+ * @param newCode the code with which to replace it
+ */
+function replaceKeyInStore(oldCode, newCode) {
+  var allResponses = JSON.parse(localStorage.getItem('formData'));
+
+  if (allResponses && allResponses[oldCode]) {
+    // swap in the new code for the replacement sentinel value
+    allResponses[newCode] = allResponses[oldCode];
+    allResponses[newCode]['participantCode'] = newCode;
+    delete allResponses[oldCode];
+    localStorage.setItem('formData', JSON.stringify(allResponses));
+  }
+}
+
+/**
+ * Removes the key 'code' from the store
+ * @param code the code to remove
+ */
+function deleteKeyInStore(code) {
+  var allResponses = JSON.parse(localStorage.getItem('formData'));
+
+  if (allResponses && allResponses[code]) {
+    // swap in the new code for the replacement sentinel value
+    delete allResponses[code];
+    localStorage.setItem('formData', JSON.stringify(allResponses));
+  }
+}
+
+/**
+ * Sets the key at 'code' to 'payload'
+ * @param code the code to update
+ * @param payload the value to which to update it
+ */
+function updateStore(code, payload) {
+  var allResponses = JSON.parse(localStorage.getItem('formData')) || {};
+  allResponses[code] = payload;
+  localStorage.setItem('formData', JSON.stringify(allResponses));
+}
+
+
+// ---------------------------------------------------------------------------------------------
+// --- form persistence, reloading
+// ---------------------------------------------------------------------------------------------
+
+function excludeField(fieldName) {
+  // skip unnamed elements and fields that aren't supposed to be persisted
+  return (
+      !fieldName ||
+      fieldName === "firstTimeSurvey" ||
+      fieldName === "participantCodeList" ||
+      fieldName === "participantCodeManual" ||
+      fieldName === "consentToStudy"
+  );
+}
+
+// persist form's current data to localStorage
+// if a participant code is specified, associate the data with that code
+// if not, associate it with REPLACE_SENTINEL, which gets replaced with a
+// code if the response is successful.
+// if the response is unsuccessful, the stored data for the sentinel value is cleared.
+// (we may want to revisit that last point later...)
+function persistForm() {
+  if (form) {
+    var payload = {};
+
+    // first, check if they consented to saving their responses; only proceed to save this user's data
+    // if they consent. if they don't consent to saving cookies, their form data is cleared.
+    var saveResponses = document.querySelector('input[name="saveResponses"]:checked').value;
+    if (saveResponses == 1) {
+      for (var i = 0; i < form.elements.length; i++) {
+        var elem = form.elements[i];
+
+        if (excludeField(elem.name)) {
+          continue;
+        }
+
+        var pageElems = document.getElementsByName(elem.name);
+
+        if (pageElems.length > 1) {
+          var isCheckboxList = pageElems[0].getAttribute('type') == 'checkbox';
+
+          if (isCheckboxList) {
+            payload[elem.name] = [];
+          }
+
+          // if there are multiple elements with this name, figure out which one is enabled
+          for (var j = 0; j < pageElems.length; j++) {
+            var option = pageElems[j];
+
+            if (option.checked) {
+              if (isCheckboxList) {
+                payload[elem.name].push(option.value)
+              } else {
+                payload[elem.name] = option.value;
+              }
+            }
+          }
+        } else if (pageElems[0]) {
+          // if there's only one element, we can just take its value
+          payload[elem.name] = elem.value;
+        }
+      }
+    }
+
+    // determine the current code. we start by assuming there's no code,
+    // then determine if they specified it somehow
+    var code = REPLACE_SENTINEL;
+
+    if (payload["firstTimeSurvey"] == 0) {
+      // it's not their first time...
+      if (payload["participantCodeList"].value != "__none__") {
+        // ...and they've selected an existing code
+        code = payload["participantCodeList"].value
+      }
+      else if (payload["participantCodeManual"].value.trim() != "") {
+        // ...and they've possibly entered a new code
+        code = payload["participantCodeManual"].value.trim()
+      }
+
+      // we also need to update the effective participant code the gets sent to the server if
+      // it's been specified by the user (otherwise it's blank and the server generates us a new code)
+      var effectiveParticipantCode = document.getElementById('effectiveParticipantCode');
+      effectiveParticipantCode.value = code;
+    }
+
+    // update just this subkey in formData
+    updateStore(code, payload);
+  }
+}
+
+// load existing form data from localStorage if present
+function rehydrateForm(fromCode) {
+  if (!form) {
+    return;
+  }
+
+  var allResponses = JSON.parse(localStorage.getItem('formData'));
+
+  if (!allResponses) {
+    return;
+  }
+
+  // either load the form data, or at least form data w/the most recent code if that's all we have
+  // (if lastCode is null, this is effectively the same as loading an empty form)
+  var payload = (fromCode && allResponses[fromCode])
+      ? allResponses[fromCode]
+      : { participantCode: fromCode };
+
+  // merge form elems with loaded data
+  for (var i = 0; i < form.elements.length; i++) {
+    var elem = form.elements[i];
+
+    if (excludeField(elem.name)) {
+      continue;
+    }
+
+    var pageElems = document.getElementsByName(elem.name);
+
+    // if there are multiple elements, it's a radio button or checkbox list
+    if (pageElems.length > 1) {
+      for (var j = 0; j < pageElems.length; j++) {
+        var option = pageElems[j];
+
+        if (option.getAttribute('type') === 'checkbox') {
+          if (payload[elem.name].includes(option.value)) {
+            option.checked = true
+          }
+        }
+        else {
+          if ((payload[elem.name] === option.value)) {
+            // click the element to get change handlers to fire
+            option.click();
+          }
+        }
+      }
+    }
+    else if (pageElems[0]) {
+      // it's a simple value
+      pageElems[0].setAttribute('value', payload[elem.name] ? payload[elem.name].trim()  : '');
+    }
+  }
+
+  // select 'no' for 'first time filling out form' prompt if there's a code
+  if (fromCode) {
+    document.getElementById('firstTimeSurvey-0').click();
+  }
+}
+
+function clearForm() {
+  for (var i = 0; i < form.elements.length; i++) {
+    var elem = form.elements[i];
+
+    if (excludeField(elem.name)) {
+      continue;
+    }
+
+    var pageElems = document.getElementsByName(elem.name);
+
+    if (pageElems.length > 1) {
+      for (var j = 0; j < pageElems.length; j++) {
+        pageElems[j].checked = false;
+      }
+    }
+    else if (pageElems[0]) {
+      pageElems[0].setAttribute('value', '');
+    }
+  }
+}

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -48,27 +48,29 @@ function checkLang() {
 }
 checkLang();
 
-if(form) {    
-  for(var i=0; i < hiddens.length; i++) {
-    hiddens[i].classList.remove('js-hide');
-    hiddens[i].classList.add('hidden');
-  }
-  
-  for(var i=0; i < toggles.length; i++) {
-    toggles[i].addEventListener('change', function(e) {
-      if(e.target.dataset.hide) {
-        document.getElementById(e.target.dataset.hide).classList.add('hidden');
-      }
-      if(e.target.dataset.show) {
-        document.getElementById(e.target.dataset.show).classList.remove('hidden');
-      }
-    });
-  }
+function setupForm() {
+  if(form) {
+    for(var i=0; i < hiddens.length; i++) {
+      hiddens[i].classList.remove('js-hide');
+      hiddens[i].classList.add('hidden');
+    }
 
-  for(var i=0; i < langLinks.length; i++) {
-    langLinks[i].addEventListener('click', function(e) {
-      localStorage.setItem('languageOverwrite', e.currentTarget.dataset.lang);
-    });
+    for(var i=0; i < toggles.length; i++) {
+      toggles[i].addEventListener('change', function(e) {
+        if(e.target.dataset.hide) {
+          document.getElementById(e.target.dataset.hide).classList.add('hidden');
+        }
+        if(e.target.dataset.show) {
+          document.getElementById(e.target.dataset.show).classList.remove('hidden');
+        }
+      });
+    }
+
+    for(var i=0; i < langLinks.length; i++) {
+      langLinks[i].addEventListener('click', function(e) {
+        localStorage.setItem('languageOverwrite', e.currentTarget.dataset.lang);
+      });
+    }
   }
 }
 
@@ -156,6 +158,7 @@ function rehydrateForm() {
 // ---------------------------------------------------------------------------------------------
 
 function run() {
+  setupForm();
   rehydrateForm();
 }
 

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -82,7 +82,6 @@ function persistForm() {
     // first, check if they consented to saving their responses; bail on saving if not
     var saveResponses = document.querySelector('input[name="saveResponses"]:checked').value;
     if (saveResponses != 1) {
-      console.warn("Not saving responses due to lack of consent");
       localStorage.removeItem('formData');
       return;
     }
@@ -122,8 +121,6 @@ function persistForm() {
         payload[elem.name] = elem.value;
       }
     }
-
-    console.log("Persisting: ", JSON.stringify(payload, null, 2));
 
     localStorage.setItem('formData', JSON.stringify(payload));
   }

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -97,12 +97,23 @@ function persistForm() {
       var pageElems = document.getElementsByName(elem.name);
 
       if (pageElems.length > 1) {
+        var isCheckboxList = pageElems[0].getAttribute('type') == 'checkbox';
+
+        if (isCheckboxList) {
+          payload[elem.name] = [];
+        }
+
         // if there are multiple elements with this name, figure out which one is enabled
         for (var j = 0; j < pageElems.length; j++) {
           var option = pageElems[j];
 
           if (option.checked) {
-            payload[elem.name] = option.value;
+            if (isCheckboxList) {
+              payload[elem.name].push(option.value)
+            }
+            else {
+              payload[elem.name] = option.value;
+            }
           }
         }
       }
@@ -111,6 +122,8 @@ function persistForm() {
         payload[elem.name] = elem.value;
       }
     }
+
+    console.log("Persisting: ", JSON.stringify(payload, null, 2));
 
     localStorage.setItem('formData', JSON.stringify(payload));
   }
@@ -130,17 +143,23 @@ function rehydrateForm() {
 
       var pageElems = document.getElementsByName(elem.name);
 
-      // if there are multiple elements, it's probably a radio button
+      // if there are multiple elements, it's a radio button or checkbox list
       if (pageElems.length > 1) {
         for (var j = 0; j < pageElems.length; j++) {
           var option = pageElems[j];
 
-          // ensure that only the matched radio button is set and all others are unset
-          // option.checked = (payload[elem.name] === option.value) || undefined;
-
-          // actually, we have to trigger an actual click to get the handlers to fire...
-          if ((payload[elem.name] === option.value)) {
-            option.click();
+          if (option.getAttribute('type') == 'checkbox') {
+            if (payload[elem.name].includes(option.value)) {
+              // FIXME: unfortunately click() isn't supported on checkboxes,
+              // so if there are change handlers they won't fire
+              option.checked = true
+            }
+          }
+          else {
+            if ((payload[elem.name] === option.value)) {
+              // click the element to get change handlers to fire
+              option.click();
+            }
           }
         }
       }

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -25,13 +25,14 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
   </head>
-  <body data-lang="<%= I18n.locale %>">  
+  <body data-lang="<%= I18n.locale %>">
     <%= yield %>
-    
+
     <%= partial "partials/footer" %>
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=Element.prototype.dataset%2Cdocument.querySelector"></script>
     <%= javascript_include_tag "date-input-polyfill.min" %>
+    <%= javascript_include_tag "persistence" %>
     <%= javascript_include_tag "site" %>
   </body>
 </html>

--- a/source/localizable/consent.de.html.erb
+++ b/source/localizable/consent.de.html.erb
@@ -1,0 +1,35 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Einverständniserklärung</h1>
+
+    <strong>Anleitung:</strong>
+    <ul>
+      <li>Bitte lesen Sie dieses Formular sorgfältig durch.</li>
+      <li>Bitte nehmen Sie Kontakt zum Studienmanagement auf, falls Sie irgendwelche Fragen haben.</li>
+    </ul>
+
+    <p>
+      <strong>Studientitel:</strong> Schweizweite Longitudinale COVID-19 Gesundheitsstudie (SloCo)
+    </p>
+
+    <p>
+      <strong>Studienort: </strong><a href="https://covidtracker.ch">https://covidtracker.ch</a> (auch erreichbar unter <a href="http://covid19survey.ch">http://covid19survey.ch</a>)</p>
+
+    <p>
+      <strong>Name des Studienleiters:</strong> <a href="https://bmi.inf.ethz.ch/people/person/gunnar-raetsch/" target="_blank">Prof. Dr. Gunnar R&auml;tsch</a></p>
+
+    <p><strong>Studienteilnehmer:</strong></p>
+
+    <ul>
+      <li>Ich nehme freiwillig an dieser Studie teil und kann jederzeit ohne Angabe von Gründen und ohne negative Folgen von der Studie zurücktreten.</li>
+      <li>Ich wurde <a href="/study_info.html" target="_blank">schriftlich</a> über die Ziele und Methoden der Studie, die Vor- und Nachteile sowie mögliche Risiken informiert.</li>
+      <li>Ich habe die schriftlichen Informationen für Teilnehmer gelesen. Mir ist bekannt, dass ich alle Fragen im Zusammenhang mit der Studie per E-Mail an <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a> richten kann. Meine Fragen zur Teilnahme an der Studie wurden zufriedenstellend beantwortet. Ich habe eine Kopie der <a href="/study_info.html" target="_blank">Informationen für Teilnehmer</a> und die <a href="/consent.html">Einverständniserklärung</a> erhalten.</li>
+      <li>Ich hatte ausreichend Zeit, um über die Teilnahme an der Studie zu entscheiden.</li>
+      <li>Durch Aktivieren des Kontrollkästchens unten bestätige ich, dass ich die Anforderungen für die Teilnahme an der Studie erfülle, die in den Informationen für Teilnehmer angegeben sind.</li>
+      <li>Ich bin damit einverstanden, dass die verantwortlichen Forscher und / oder die Mitglieder der Ethikkommission unter streng eingehaltenen Vertraulichkeitsregeln Zugang zu den Originaldaten haben.</li>
+      <li>Mir ist bewusst, dass ich während der Studienteilnahme die Anforderungen und Einschränkungen einhalten muss, die in den Informationen für Teilnehmer beschrieben sind. Die Untersuchungsleiter können mich ohne gegenseitiges Einverständnis von der Studie ausschließen.</li>
+    </ul>
+  </section>
+</div>

--- a/source/localizable/consent.en.html.erb
+++ b/source/localizable/consent.en.html.erb
@@ -1,0 +1,35 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Terms of Consent</h1>
+
+    <strong>Instructions:</strong>
+    <ul>
+      <li>Please read this form carefully.</li>
+      <li>Please ask the investigator or the contact person if you have any questions.</li>
+    </ul>
+
+    <p>
+      <strong>Study title:</strong> Swiss-wide Longitudinal COVID-19 Health Survey (SloCo)
+    </p>
+
+    <p>
+      <strong>Study location: </strong><a href="https://covidtracker.ch">https://covidtracker.ch</a> (also available at <a href="http://covid19survey.ch">http://covid19survey.ch</a>)</p>
+
+    <p>
+      <strong>Principal Investigator's Name and First Name:</strong> <a href="https://bmi.inf.ethz.ch/people/person/gunnar-raetsch/" target="_blank">Prof. Dr. Gunnar R&auml;tsch</a></p>
+
+    <p><strong>Participant:</strong></p>
+
+    <ul>
+      <li>I participate in this study on a voluntary basis and can withdraw from the study at any time without giving reasons and without any negative consequences.</li>
+      <li>I have been informed <a href="/study_info.html" target="_blank">in writing</a> about the aims and the procedures of the study, the advantages and disadvantages, as well as potential risks.</li>
+      <li>I have read the written information for the volunteers. I am aware that I can direct all questions related to the study via e-mail to <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>. My questions related to participating in the study have been answered satisfactorily. I have been given a copy of the <a href="/study_info.html" target="_blank">information for volunteers</a> and the <a href="/consent.html">consent form</a>.</li>
+      <li>I was given sufficient time to make a decision about participating in the study.</li>
+      <li>By checking the box at the end of the survey, I certify that I fulfill the requirements for participating in the study stated in the information for the volunteers.</li>
+      <li>I agree that the responsible investigators and/or the members of the Ethics Commission have access to the original data under strictly observed rules of confidentiality.</li>
+      <li>I am aware that during the study, I have to comply with the requirements and limitations described in the information for volunteers. The investigators can, without mutual consent, exclude me from the study.</li>
+    </ul>
+  </section>
+</div>

--- a/source/localizable/consent.fr.html.erb
+++ b/source/localizable/consent.fr.html.erb
@@ -1,0 +1,35 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Formulaire de consentement</h1>
+
+    <strong>Instructions:</strong>
+    <ul>
+      <li>Veuillez lire ce formulaire avec l’attention.</li>
+      <li>N’hésitez pas à contacter la personne en charge de l’étude ou le directeur de recherche pour toute question.</li>
+    </ul>
+
+    <p>
+      <strong>Titre de l’étude:</strong> Enquête longitudinale de santé COVID-19 l’échelle de la Suisse (SloCo)
+    </p>
+
+    <p>
+      <strong>Lieu de l’étude: </strong><a href="https://covidtracker.ch">https://covidtracker.ch</a> (également disponible à <a href="http://covid19survey.ch">http://covid19survey.ch</a>)</p>
+
+    <p>
+      <strong>Nom et prénom du chercheur principal</strong>: <a href="https://bmi.inf.ethz.ch/people/person/gunnar-raetsch/" target="_blank">Prof. Dr. Gunnar R&auml;tsch</a></p>
+
+    <p><strong>Participant:</strong></p>
+
+    <ul>
+      <li>Je participe à cette étude sur une base volontaire et je dispose d’un droit de retrait à tout moment sans avoir à fournir de justification et sans m’exposer à des conséquences négatives.</li>
+      <li>J’ai été informé de manière <a href="/study_info.html" target="_blank">écrite</a> des objectifs et des modalités de l’étude, des avantages et inconvénients ainsi que des risques encourus.</li>
+      <li>J’ai lu la fiche d’informations à l’attention des participants. Je suis conscient que je peux adresser mes questions à propos de l’étude par e-mail à <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>. Mes questions concernant la participation à l'étude ont reçu une réponse satisfaisante. J’ai reçu une copie de la fiche <a href="/study_info.html" target="_blank">d’information aux participants</a> ainsi que le <a href="/consent.html">formulaire de consentement</a>.</li>
+      <li>J’ai disposé de suffisamment de temps pour me décider à participer à l’étude.</li>
+      <li>En cochant la case ci-dessous, je certifie que je remplis les prérequis énoncés dans la fiche d’information aux participants.</li>
+      <li>J’autorise les personnes en charge de l’étude et les membres de la commission éthique à accéder aux données brutes, dans le respect des règles de confidentialité.</li>
+      <li>Je suis conscient que pendant la durée de l’étude je dois me conformer aux règles et aux limites décrites dans la fiche d’information aux participants. Les responsables de l’étude disposent du droit de m’exclure de l’étude sans requérir mon consentement.</li>
+    </ul>
+  </section>
+</div>

--- a/source/localizable/consent.it.html.erb
+++ b/source/localizable/consent.it.html.erb
@@ -1,0 +1,35 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Dichiarazione di consenso</h1>
+
+    <strong>Istruzioni:</strong>
+    <ul>
+      <li>Si prega di leggere attentamente questo modulo.</li>
+      <li>In caso di domande, si prega di chiedere allo sperimentatore o alla persona di contatto.</li>
+    </ul>
+
+    <p>
+      <strong>Titolo dello studio:</strong> Swiss Longitudinal COVID-19 Health Survey (SloCo)
+    </p>
+
+    <p>
+      <strong>Luogo di studio: </strong><a href="https://covidtracker.ch">https://covidtracker.ch</a> (disponibile anche a <a href="http://covid19survey.ch">http://covid19survey.ch</a>)</p>
+
+    <p>
+      <strong>Nome del responsabile dello studio:</strong> <a href="https://bmi.inf.ethz.ch/people/person/gunnar-raetsch/" target="_blank">Prof. Dr. Gunnar R&auml;tsch</a></p>
+
+    <p><strong>Partecipante:</strong></p>
+
+    <ul>
+      <li>Partecipo a questo studio su base volontaria e posso ritirarmi dallo studio in qualsiasi momento senza fornire motivazioni e senza conseguenze negative.</li>
+      <li>Sono stato informato per <a href="/study_info.html" target="_blank">iscritto</a> degli obiettivi e delle procedure dello studio, dei vantaggi e degli svantaggi, nonché dei potenziali rischi.</li>
+      <li>Ho letto le informazioni scritte per i volontari. Sono consapevole di poter inviare tutte le domande relative allo studio via e-mail a <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>. Le mie domande relative alla partecipazione allo studio hanno avuto una risposta soddisfacente. Mi è stata data una copia delle <a href="/study_info.html" target="_blank">informazioni per i volontari</a> e il <a href="/consent.html">modulo di consenso</a>.</li>
+      <li>Mi è stato concesso il tempo sufficiente per prendere una decisione sulla partecipazione allo studio.</li>
+      <li>Selezionando la casella qui sotto, certifico di soddisfare i requisiti per la partecipazione allo studio indicati nelle informazioni per i volontari.</li>
+      <li>Accetto che gli investigatori responsabili e / o i membri della Commissione etica abbiano accesso ai dati originali secondo le rigorose regole di riservatezza.</li>
+      <li>Sono consapevole che durante lo studio devo rispettare i requisiti e i limiti descritti nelle informazioni per i volontari. Gli investigatori possono, senza mutuo consenso, escludermi dallo studio.</li>
+    </ul>
+  </section>
+</div>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -29,7 +29,35 @@
 
 <div class="form" id="form">
   <div class="container">
-    <form action="https://backend.covidtracker.ch/form" onsubmit="persistForm()" method="post" id="covid-form">
+
+    <form action="http://localhost:5000/form" onsubmit="persistForm()" method="post" id="covid-form">
+      <div class="input-wrap input-wrap--radio">
+        <span class="label"><%= t(:firstTimeForm) %> *</span>
+        <div class="radio-wrap">
+          <label class="radio-item" for="firstTimeSurvey-1">
+            <input class="js-toggle input" type="radio" name="firstTimeSurvey" id="firstTimeSurvey-1" value="1" data-hide="wrap-participantcode" required>
+            <span><%= t(:yesAnswer) %></span>
+          </label>
+          <label class="radio-item" for="firstTimeSurvey-0">
+            <input class="js-toggle input" type="radio" name="firstTimeSurvey" id="firstTimeSurvey-0" value="0" data-show="wrap-participantcode" required>
+            <span><%= t(:noAnswer) %></span>
+          </label>
+        </div>
+      </div>
+
+      <div id="wrap-participantcode" class="input-wrap input-wrap--text js-hide">
+        <label class="label" for="participantCodeList"><%= t(:participantCode) %></label>
+        <select id="participantCodeList" name="participantCodeList" class="dropdown code">
+          <option value="__none__"><%= t(:unlistedCode) %></option>
+        </select>
+        <div id="participantCodeManualBox" class="input-wrap input-wrap--text hidden">
+          <label class="label" for="participantCodeManual"><%= t(:manualParticipantCode) %></label>
+          <input id="participantCodeManual" name="participantCodeManual" class="input input--short">
+        </div>
+
+        <input type="hidden" id="effectiveParticipantCode" name="participantCode" />
+      </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:sex) %> *</span>
         <div class="radio-wrap">
@@ -302,6 +330,7 @@
 
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:saveResponses) %> *</span>
+        <span class="subtext"><%= t(:cookieWarning) %></span>
         <div class="radio-wrap">
           <label class="radio-item" for="saveResponses-1">
             <input class="input" type="radio" name="saveResponses" id="saveResponses-1" value="1" required>
@@ -309,6 +338,20 @@
           </label>
           <label class="radio-item" for="saveResponses-0">
             <input class="input" type="radio" name="saveResponses" id="saveResponses-0" value="0" required>
+            <span><%= t(:noAnswer) %></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="input-wrap input-wrap--radio">
+        <span class="label"><%= t(:consentToStudy) %> *</span>
+        <div class="radio-wrap">
+          <label class="radio-item" for="consentToStudy-1">
+            <input class="input" type="radio" name="consentToStudy" id="consentToStudy-1" value="1" required>
+            <span><%= t(:yesAnswer) %></span>
+          </label>
+          <label class="radio-item" for="consentToStudy-0">
+            <input class="input" type="radio" name="consentToStudy" id="consentToStudy-0" value="0" required>
             <span><%= t(:noAnswer) %></span>
           </label>
         </div>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -47,14 +47,17 @@
           </label>
         </div>
       </div>
+
       <div class="input-wrap input-wrap--text">
         <label class="label" for="yearOfBirth"><%= t(:birthyear) %> *</label>
         <input id="yearOfBirth" name="yearOfBirth" class="input input--short" type="number" max="2020" min="1900" step="1" required>
       </div>
+
       <div class="input-wrap input-wrap--text">
         <label class="label" for="zip"><%= t(:zip) %> *</label>
         <input id="zip" name="zip" class="input input--short" type="number" max="9999" min="1000" step="1" required>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:hasBeenTested) %></span>
         <div class="radio-wrap">
@@ -68,6 +71,7 @@
           </label>
         </div>
       </div>
+
       <div id="wrap-tested" class="js-hide">
         <div class="input-wrap input-wrap--child input-wrap--radio">
           <span class="label"><%= t(:testResult) %></span>
@@ -91,6 +95,7 @@
           <input id="whereTested" name="whereTested" class="input" type="text" maxlength="30">
         </div>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:worksInHealth) %></span>
         <div class="radio-wrap">
@@ -116,6 +121,7 @@
           </label>
         </div>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:wasAbroad) %></span>
         <div class="radio-wrap">
@@ -145,6 +151,7 @@
           </label>
         </div>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:wasInContactWithCase) %></span>
         <div class="radio-wrap">
@@ -158,10 +165,12 @@
           </label>
         </div>
       </div>
+
       <div class="input-wrap input-wrap--text input-wrap--child js-hide" id="wrap-dateContacted">
         <label class="label" for="dateContacted"><%= t(:dateContacted) %></label>
         <input id="dateContacted" name="dateContacted" class="input input--short" type="date" min="2019-11-01" max="2020-12-31">
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:chronicCondition) %></span>
         <div class="radio-wrap">
@@ -187,6 +196,7 @@
           </label>
         </div>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:feelsHealthy) %> *</span>
         <div class="radio-wrap">
@@ -200,6 +210,7 @@
           </label>
         </div>
       </div>
+
       <div id="form-expanded" class="js-hide">
         <span class="section-title"><%= t(:followingSymptoms) %></span>
         <div class="input-wrap input-wrap--radio">
@@ -288,19 +299,21 @@
           <input id="throatSince" name="throatSince" class="input input--short" type="number">
         </div>
       </div>
+
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:saveResponses) %> *</span>
         <div class="radio-wrap">
           <label class="radio-item" for="saveResponses-1">
-            <input class="js-toggle input" type="radio" name="saveResponses" id="saveResponses-1" value="1" required>
+            <input class="input" type="radio" name="saveResponses" id="saveResponses-1" value="1" required>
             <span><%= t(:yesAnswer) %></span>
           </label>
           <label class="radio-item" for="saveResponses-0">
-            <input class="js-toggle input" type="radio" name="saveResponses" id="saveResponses-0" value="0" required>
+            <input class="input" type="radio" name="saveResponses" id="saveResponses-0" value="0" required>
             <span><%= t(:noAnswer) %></span>
           </label>
         </div>
       </div>
+
       <button type="submit" class="btn" id="btn-send"><%= t(:sendForm) %></button>
     </form>
   </div>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -29,7 +29,7 @@
 
 <div class="form" id="form">
   <div class="container">
-    <form action="https://backend.covidtracker.ch/form" method="post" id="covid-form">
+    <form action="https://backend.covidtracker.ch/form" onsubmit="persistForm()" method="post" id="covid-form">
       <div class="input-wrap input-wrap--radio">
         <span class="label"><%= t(:sex) %> *</span>
         <div class="radio-wrap">
@@ -286,6 +286,19 @@
         <div class="input-wrap input-wrap--text input-wrap--child js-hide" id="wrap-throatSince">
           <label class="label" for="throatSince"><%= t(:sinceHowManyDays) %></label>
           <input id="throatSince" name="throatSince" class="input input--short" type="number">
+        </div>
+      </div>
+      <div class="input-wrap input-wrap--radio">
+        <span class="label"><%= t(:saveResponses) %> *</span>
+        <div class="radio-wrap">
+          <label class="radio-item" for="saveResponses-1">
+            <input class="js-toggle input" type="radio" name="saveResponses" id="saveResponses-1" value="1" required>
+            <span><%= t(:yesAnswer) %></span>
+          </label>
+          <label class="radio-item" for="saveResponses-0">
+            <input class="js-toggle input" type="radio" name="saveResponses" id="saveResponses-0" value="0" required>
+            <span><%= t(:noAnswer) %></span>
+          </label>
         </div>
       </div>
       <button type="submit" class="btn" id="btn-send"><%= t(:sendForm) %></button>

--- a/source/localizable/response.en.html.erb
+++ b/source/localizable/response.en.html.erb
@@ -4,6 +4,9 @@
   <section class="subpage">
     <h2>Thanks!</h2>
     <p>Thank you for answering our questionnaire. Together we are stronger.</p>
+
+    <p>Your participation code is: <span id="yourCodeHere" class="code"></span></p>
+
     <p>Please fill out the form again, if:</p>
     <ul class="list">
       <li>One of the symptoms occurs</li>

--- a/source/localizable/study_info.de.html.erb
+++ b/source/localizable/study_info.de.html.erb
@@ -1,0 +1,63 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Information für Teilnehmer</h1>
+
+    <p>
+      <strong>Studientitel: </strong>
+      Schweizweite Longitudinale COVID-19 Gesundheitsstudie (SloCo; ETH Zurich Ethikbewilligung 2020-N-42)
+    </p>
+
+    <p>
+      <strong>Studienziele</strong>
+      Ziel dieser Studie ist es, anonymisierte personenbezogene Gesundheitsdaten einer breiten schweizer Öffentlichkeit zu COVID-19 zu sammeln. Diese Daten werden verwendet, um Änderungen der Schweizer Gesundheitssituation in Echtzeit zu überwachen und darzustellen und können dazu beitragen, Vorhersagemodelle zu erstellen, die möglicherweise bei der Entwicklung von Maßnahmen zur Minderung der Pandemie hilfreich sein könnten.
+    </p>
+
+    <p>
+      <strong>Forschungsverfahren und -plan</strong>
+      Die Studie ist als Online-Umfrage konzipiert, und basiert auf der Sammlung de-identifizierter Gesundheitsinformationen in Bezug auf COVID-19. Die Informationen werden nach Postleitzahlbereichen zusammengefasst und öffentlich zugänglich gemacht. Nicht aggregierte Rohdaten werden epidemiologischen Forschern in der Schweiz zur Verfügung gestellt, um die Modellierung der Ausbreitung zu verbessern und die Erfolgsrate von Eindämmungsmassnahmen zu bewerten. Die Teilnehmer werden gebeten, täglich an der Umfrage teilzunehmen. Die Datenerfassung wird ab März 2020 mindestens für ein Jahr andauern.
+
+    </p>
+
+    <p>
+      <strong>Teilnahmebedingungen</strong>
+      Jede natürliche Person mit einem Alter von 18 Jahren oder darüber ist zur Teilnahme an der Studie berechtigt. Eine/e Teilnehmer/in kann die Daten entweder für sich selbst oder als Elternteil oder gesetzlicher Vormund für eine Person jünger als 18 Jahre eingeben.
+    </p>
+
+    <p>
+      <strong>Nutzen und Risiken der Teilnahme</strong>
+      Der Nutzen für die Teilnehmer stellt sich durch eine genauere Abschätzung ihres lokalen epidemiologischen Risikos anhand ihrer Postleitzahl dar. Da diese Studie anonym durchgeführt wird, ist das Risiko einer Identifizierung der Teilnehmer sehr gering. Verschiedene Maßnahmen wie bspw. Aggregation von Daten und k-Anonymität werden ergriffen, um die de- identifizierten Daten vor versuchter Re-Identifizierung zu schützen.
+    </p>
+
+    <p>
+      <strong>Finanzierungsquelle</strong>
+      Diese Studie wird aus Mitteln der ETH Zürich finanziert.
+    </p>
+
+    <p>
+      <strong>Entschädigung</strong>
+      Die Teilnehmer erhalten keine (finanzielle oder sonstige) Entschädigung für die Teilnahme an dieser Studie.
+    </p>
+
+    <p>
+      <strong>Widerrufsrecht</strong>
+      Alle Teilnehmer können jederzeit ohne weitere Mitteilung an die ETH oder das Studienmanagement die Teilnahme an der Studie einstellen. Anonyme Daten, die bis zum Zeitpunkt des Abbruchs gesammelt wurden, bleiben Teil des Datensatzes der Studie.
+    </p>
+
+    <p>
+      <strong>Datenschutz</strong>
+      Alle erhaltenen Daten werden sicher auf ETH-Servern in der Schweiz gespeichert und anonym gesammelt. Den Teilnehmern wird ein zufälliger Teilnehmercode zugewiesen. Es werden keine personenbezogenen Daten angefordert oder gesammelt.
+    </p>
+
+    <p>
+      <strong>Versicherungsschutz</strong>
+      Mögliche Gesundheitsschäden, die in direktem Zusammenhang mit der Studie stehen und nachweislich von der ETH Zürich verschuldet werden, sind durch die allgemeine Haftpflichtversicherung der ETH Zürich (Versicherungspolice Nr. 30 / 4.078.362 der Basler Versicherung AG) gedeckt. Über das zuvor Erwähnte hinaus liegt die Krankenversicherung und die Unfallversicherung (z. B. der Weg zum oder vom Studienort) in der Verantwortung des Teilnehmers.
+    </p>
+
+    <p>
+      <strong>Ansprechpartner</strong>
+      Bei Fragen wenden Sie sich bitte an Prof. Dr. Gunnar R&auml;tsch unter <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>.
+    </p>
+  </section>
+</div>

--- a/source/localizable/study_info.en.html.erb
+++ b/source/localizable/study_info.en.html.erb
@@ -1,0 +1,63 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Information sheet for participants</h1>
+
+    <p>
+      <strong>Study title: </strong>
+      Swiss-wide Longitudinal COVID-19 Health Survey (SloCo; ETH Zurich Ethics approval 2020-N-42)
+    </p>
+
+    <p>
+      <strong>Study goals</strong>
+      The goal of this study is to collect personal health data related to the COVID-19 disease across the public in Switzerland. This data will be used to monitor and display changes in the Swiss health situation real-time and may help to build predictive models that could possibly assist in designing measures of mitigation of the pandemic.
+    </p>
+
+    <p>
+      <strong>Research procedure and schedule</strong>
+      The study is designed as an online survey. Non-identifying health information related to COVID-19 will be collected. Information will be aggregated per Zip-code area and made available publicly. Un-aggregated information will be made available to epidemiology researchers in Switzerland to improve the modeling of spread and evaluate the success rate of containment measures. Participants are encouraged to take the survey on a daily basis. Data collection will comprise at least one year, beginning in March 2020.
+
+    </p>
+
+    <p>
+      <strong>Conditions for participation</strong>
+      Any natural person of the age of 18 years or above can participate in the study. A participant can provide the data directly for him-/herself or as a parent or guardian on behalf of a person under the age of 18.
+    </p>
+
+    <p>
+      <strong>Benefits and Risks of participation</strong>
+      The benefits for participants are a more exact estimation of their local epidemiological risk with their zip-code area. It helps to inform and to plan any personal action. As this study is conducted anonymously, the risk of re-identifying participants is very small. Various measures, such as aggregation and k-anonymity, are taken to secure the de-identified data against re-identification attacks.
+    </p>
+
+    <p>
+      <strong>Source of funding</strong>
+      This study is funded from ETH Zurich core resources.
+    </p>
+
+    <p>
+      <strong>Compensation</strong>
+      Participants will receive no compensation (financial or otherwise) for taking part in this study.
+    </p>
+
+    <p>
+      <strong>Right of withdrawal</strong>
+      All participants can stop contributing to the study at any point in time without further notice to ETH or the study management. Anonymous data collected up to the time point of drop out, will remain part of the study data set.
+    </p>
+
+    <p>
+      <strong>Data protection</strong>
+      All obtained data will be stored safely on ETH servers in Switzerland and collected in an anonymous form. Participants will be assigned a random study code. No personally-identifying information is requested or collected.
+    </p>
+
+    <p>
+      <strong>Insurance coverage</strong>
+      Possible damages to health, which are directly related to the study and are demonstrably the fault of ETH Zurich, are covered by the general liability insurance of ETH Zurich (Insurance Policy No. 30/4.078.362 of the Basler Versicherung AG). Beyond the before mentioned, the health insurance and the accident insurance (e.g., the commute to or from the study location) is the responsibility of the participant.
+    </p>
+
+    <p>
+      <strong>Contact persons</strong>
+      In case of any questions, please contact Prof. Dr. Gunnar R&auml;tsch under <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>.
+    </p>
+  </section>
+</div>

--- a/source/localizable/study_info.fr.html.erb
+++ b/source/localizable/study_info.fr.html.erb
@@ -1,0 +1,63 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Information aux participants</h1>
+
+    <p>
+      <strong>Titre de l’étude: </strong>
+      Enquête longitudinale de santé COVID-19 l’échelle de la Suisse (SloCo; Approbation Ethique ETH Zurich 2020-N-42)
+    </p>
+
+    <p>
+      <strong>But de l’étude </strong>
+      L’objectif de cette étude est de collecter auprès de la population suisse des données de santé personnalisée liées à l’infection COVID-19. Ces données seront utilisées pour suivre et visualiser les changements de la situation sanitaire en temps réel. Elles seront potentiellement utilisées afin de créer des modèles mathématiques prédictifs et afin de mettre en place des mesures de réponse à la pandémie.
+    </p>
+
+    <p>
+      <strong>Protocole expérimental et déroulement de l’étude</strong>
+      Cette étude prend la forme d’un questionnaire en ligne. Des informations médicales mais n’exposant pas l’identité des individus vont être collectées. Les informations vont être agrégées par code postal est vont être mises à disposition du public. Les données non agrégées vont être mises à la disposition des chercheurs en épidémiologie en Suisse afin d’améliorer la modélisation de la transmission de la maladie et d’évaluer le succès des mesures de confinement. Les participants sont encouragés à remplir le sondage quotidiennement. La collection de données va durer au moins un an, à compter de mars 2020.
+
+    </p>
+
+    <p>
+      <strong>Conditions de participation</strong>
+      Toute personne physique majeure peut participer à l’étude. Un participant peut fournir les données directement pour lui-même ou en tant que parent ou tuteur au nom d'une personne de moins de 18 ans.
+    </p>
+
+    <p>
+      <strong>Avantages et risques liés à la participation</strong>
+      Les bénéfices pour les participants sont une estimation plus précise du risque épidémiologique au sein de leur localité (code postal). Dans le cadre d’une collecte anonyme des données le risque de re-identification des individus est très faible. La protection contre des attaques potentielles de ré-identification est garantie par diverse mesures, telles que l’agrégation et la k-anonymisation.
+    </p>
+
+    <p>
+      <strong>Financement</strong>
+      Cette étude est financée par le fond principal de ETH Zurich.
+    </p>
+
+    <p>
+      <strong>Compensation</strong>
+      Les participants à l’étude recevront aucune compensation (financière ou autre).
+    </p>
+
+    <p>
+      <strong>Droit de rétractation </strong>
+      Tous les participants peuvent se retirer de l’étude à tout moment sans préavis après de l’ETH Zurich ou du service de management des études. Les données anonymes collectées jusqu’à la rétractation seront conservées dans l’ensemble de données étudiées.
+    </p>
+
+    <p>
+      <strong>Protection des données</strong>
+      Toutes les données obtenues vont être stockées de manière sécurisée sur les serveurs l’ ETH Zurich en Suisse. Toutes les données vont être collectées de manière anonyme. Les participants se verront assigner un code d’identification aléatoire. Aucune donnée permettant d’identifier personnellement les participants ne sera requise ou collecté.
+    </p>
+
+    <p>
+      <strong>Police d’assurance</strong>
+      Dans le cas d’un lien de causalité avéré entre la participation et un problème de santé, l’ETH Zurich s’engage à couvrir ce dernier via son assurance responsabilité civile générale (police d’assurance No. 30/4.078.362 Basler assurance AG). Dans le cas où la causalité ne serait pas établie et pour tout autre accident (eg. Accident entre le domicile et le lieu de l’étude), la couverture est à la charge de l’assurance santé ou accident du participant.
+    </p>
+
+    <p>
+      <strong>Contact</strong>
+      Pour toute question veuillez contacter le professeur Dr. Gunnar  R&auml;tsch, par e-mail <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>.
+    </p>
+  </section>
+</div>

--- a/source/localizable/study_info.it.html.erb
+++ b/source/localizable/study_info.it.html.erb
@@ -1,0 +1,63 @@
+<%= partial "partials/header" %>
+<%= partial "partials/homelink" %>
+<div class="container">
+  <section class="subpage">
+    <h1>Foglio informativo per i partecipanti</h1>
+
+    <p>
+      <strong>Titolo dello studio </strong>
+      Swiss-wide Longitudinal COVID-19 Health Survey (SloCo; ETH Zurich Approvazione etica 2020-N-42)
+    </p>
+
+    <p>
+      <strong>Obiettivi dello studio</strong>
+      L'obiettivo di questo studio è di raccogliere dati sulla salute personale relativi alla malattia di COVID-19 in tutto il pubblico in Svizzera. Questi dati verranno utilizzati per monitorare e visualizzare in tempo reale i cambiamenti della situazione sanitaria Svizzera e potrebbero aiutare a costruire modelli predittivi che potrebbero eventualmente aiutare a progettare misure di mitigazione della pandemia.
+    </p>
+
+    <p>
+      <strong>Procedura e programma di ricerca</strong>
+      Lo studio è concepito come un sondaggio online. Verranno raccolte informazioni sanitarie non identificative relative a COVID-19. Le informazioni verranno aggregate per area di codice postale e rese disponibili al pubblico. Informazioni non aggregate saranno rese disponibili ai ricercatori dell'epidemiologia in Svizzera per migliorare la modellizzazione della diffusione e valutare il tasso di successo delle misure di contenimento. I partecipanti sono incoraggiati a partecipare al sondaggio su base giornaliera. La raccolta dei dati comprenderà almeno un anno, a partire da marzo 2020.
+    </p>
+
+    <p>
+      <strong>Condizioni di partecipazione</strong>
+      Qualsiasi persona fisica di età pari o superiore a 18 anni può partecipare allo studio. Un partecipante può fornire i dati direttamente per se stesso o come genitore o tutore per conto di una persona di età inferiore ai 18 anni.
+    </p>
+
+    <p>
+      <strong>Vantaggi e rischi della partecipazione</strong>
+      I benefici per i partecipanti sono una stima più esatta del loro rischio epidemiologico locale con la loro area di codice postale. Poiché questo studio è condotto in forma anonima, il rischio di reidentificazione dei partecipanti è molto ridotto. Varie misure, come l'aggregazione e l'anonimato-k, sono adottate per proteggere i dati non identificati da attacchi di reidentificazione.
+    </p>
+
+    <p>
+      <strong>Fonte di finanziamento</strong>
+      Questo studio è finanziato dalle risorse dell'ETH di Zurigo.
+    </p>
+
+    <p>
+      <strong>Compensazione</strong>
+      I partecipanti non riceveranno alcun compenso (finanziario o di altro tipo) per la partecipazione a questo studio.
+    </p>
+
+    <p>
+      <strong>Diritto di recesso</strong>
+      Tutti i partecipanti possono smettere di contribuire allo studio in qualsiasi momento senza ulteriore avviso all'ETH o alla direzione dello studio. I dati anonimi raccolti fino al momento del ritiro, rimarranno parte del set di dati di studio.
+    </p>
+
+    <p>
+      <strong>Protezione dei dati</strong>
+      Tutti i dati ottenuti verranno archiviati in modo sicuro sui server ETH in Svizzera e raccolti in forma anonima. Ai partecipanti verrà assegnato un codice di studio casuale. Non vengono richieste o raccolte informazioni di identificazione personale.
+    </p>
+
+    <p>
+      <strong>Copertura assicurativa</strong>
+      Eventuali danni alla salute, che sono direttamente correlati allo studio e che sono manifestamente imputabili all'ETH di Zurigo, sono coperti dall'assicurazione di responsabilità civile generale dell'ETH di Zurigo (Polizza assicurativa n. 30 / 4.078.362 della Basler Versicherung AG). Oltre a quanto sopra menzionato, l'assicurazione sanitaria e l'assicurazione infortuni (ad es. Il pendolarismo da o verso il luogo di studio) sono a carico del partecipante.
+
+    </p>
+
+    <p>
+      <strong>Contatti</strong>
+      In caso di domande, si prega di contattare il Prof. Dr. Gunnar R&auml;tsch sotto <a href="mailto:info@covid19survey.ch">info@covid19survey.ch</a>.
+    </p>
+  </section>
+</div>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -72,6 +72,9 @@ ul.list {
   &:hover {
     background-color: #c00;
   }
+  &:disabled {
+    background-color: #f5b8b8;
+  }
   &--inv {
     background-color: #fff;
     color: $c-highlight-dark;
@@ -131,6 +134,15 @@ ul.list {
     font-size: .8rem;
     color: #666;
     font-weight: bold;
+    margin-bottom: .5rem;
+    letter-spacing: .02rem;
+  }
+  .subtext {
+    display: block;
+    font-size: .8rem;
+    color: #999;
+    font-style: oblique;
+    font-weight: normal;
     margin-bottom: .5rem;
     letter-spacing: .02rem;
   }
@@ -214,6 +226,17 @@ ul.list {
     }
   }
 }
+
+.dropdown {
+  font-family: $f-main;
+  border-radius: 3px;
+}
+
+.code {
+  font-size: 1rem;
+  font-family: monospace;
+}
+
 .section-title {
   display: block;
   margin-top: 6rem;


### PR DESCRIPTION
This PR adds quite a few features:
- Adds a prompt inquiring whether the user is taking the survey for the first time.
  * If yes, the form displays a participant code selector with a "not in list" option
     * If an existing code is selected, populates the form with their previous answers.
     * If the "not in list" option is selected, displays an input box for the code.
  * At the end of this process, they either have a blank code or a specified code; blank codes get replaced with a server-generated code when the server accepts the submission.
- Adds prompts to consent to using cookies
   * If enabled, the form is saved in localStorage under their participant code.
   * If this the first time they're filling the form or they left the participant code blank, the code is associated with their data once the server returns a response. (The server generates and sends the code back on submission.)
   * If the server returns an error, the form data associated with the temporary code is deleted. (We might consider keeping it, but it introduces some complexity in the flow.)
- Adds prompt to consent to the terms of participation of the study
   * The submit button is disabled until they agree. This consent must be given each time.
- Adds consent, study info pages. (Not currently linked in the header, though.)
