### PR TITLE
Adds migration data handler to frontend

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -74,8 +74,8 @@ ready do
 end
 
 # set the API url to the staging server by default, but override when building locally
-config[:api_url] = "https://covid-stage.apps-customer.210235761750.ninegcp.ch"
-# config[:api_url] = "https://backend.covidtracker.ch"
+# config[:api_url] = "https://covid-stage.apps-customer.210235761750.ninegcp.ch"
+config[:api_url] = "https://backend.covidtracker.ch"
 configure :development do
   config[:api_url] = "http://localhost:5000"
 end

--- a/config.rb
+++ b/config.rb
@@ -74,8 +74,8 @@ ready do
 end
 
 # set the API url to the staging server by default, but override when building locally
-# config[:api_url] = "https://covid-stage.apps-customer.210235761750.ninegcp.ch"
-config[:api_url] = "https://backend.covidtracker.ch"
+config[:api_url] = "https://covid-stage.apps-customer.210235761750.ninegcp.ch"
+# config[:api_url] = "https://backend.covidtracker.ch"
 configure :development do
   config[:api_url] = "http://localhost:5000"
 end

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -277,37 +277,6 @@ function bindParticipantsList(lastCode) {
   }
 }
 
-function selectExistingCode(code, isManual) {
-  var firstTime_No = document.getElementById('firstTimeSurvey-0');
-  var participantCodeList = document.getElementById('participantCodeList');
-  var participantCodeManualBox = document.getElementById('participantCodeManualBox');
-  var participantCodeManual = document.getElementById('participantCodeManual');
-
-  if (code && firstTime_No && participantCodeList && participantCodeManual) {
-    firstTime_No.checked = true;
-    document.getElementById(firstTime_No.dataset.show).classList.remove('hidden');
-
-    if (isManual) {
-      participantCodeManualBox.classList.remove('hidden');
-      participantCodeList.value = '__none__';
-      participantCodeManual.value = code;
-      clearForm();
-    }
-    else {
-      console.log("Selecting value ", code, " from options: ", participantCodeList.options);
-      for (var i = 0; i < participantCodeList.options.length; i++) {
-        var curOption = participantCodeList.options[i];
-        if (curOption.value === code) {
-          console.log("Found! ", i);
-          participantCodeList.selectedIndex = i;
-          curOption.selected = true;
-          // break;
-        }
-      }
-    }
-  }
-}
-
 function checkForMigrationData() {
   var params = searchParams();
 
@@ -338,16 +307,26 @@ function checkForMigrationData() {
 }
 
 function checkForMigrationCode() {
+  // if there's a migration code and we're on the homepage, prefill it into the
+  // "other code" box.
+  // (note that this is one of two mechanisms for accepting migration codes;
+  // the second mechanism is checkForMigrationData() above.)
+
   var params = searchParams();
 
-  // if there's a migration code and we're on the homepage, prefill it
-  // (yes, i'm aware that this is less than attractive...)
   var firstTime_No = document.getElementById('firstTimeSurvey-0');
   var participantCodeList = document.getElementById('participantCodeList');
   var participantCodeManual = document.getElementById('participantCodeManual');
 
   if (params['migration_code'] && firstTime_No && participantCodeList && participantCodeManual) {
-    selectExistingCode(params['migration_code'], true);
+    // sets the
+    firstTime_No.checked = true;
+    document.getElementById(firstTime_No.dataset.show).classList.remove('hidden');
+
+    participantCodeManualBox.classList.remove('hidden');
+    participantCodeList.value = '__none__';
+    participantCodeManual.value = params['migration_code'];
+    clearForm();
   }
 }
 


### PR DESCRIPTION
This PR introduces a mechanism for accepting migrated participant codes and some limited form data (specifically, the age range and gender of participants) from the previous tracker at covid19survey.ethz.ch.

Once this PR is merged and goes live, I'll switch over covid19survey.ethz.ch to display the migration message.