### PR TITLE
Adds blog permalinks

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,7 @@ activate :i18n, :mount_at_root => :de
 
 activate :blog do |blog|
   blog.sources = "blog/posts/{year}-{month}-{day}/{lang}.html"
-  blog.permalink = "{lang}/blog/posts/{year}/{month}/{day}/{title}.html"
+  blog.permalink = "{lang}/blog/posts/{year}/{month}/{day}/{permalink}.html"
   blog.default_extension = 'html'
   blog.layout = 'blog_layout'
   blog.paginate = true

--- a/source/blog/posts/2020-03-20/de.html.erb
+++ b/source/blog/posts/2020-03-20/de.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: behind the scenes
 title: Hinter den Kulissen
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-03-20/en.html.erb
+++ b/source/blog/posts/2020-03-20/en.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: behind the scenes
 title: Behind the Scenes
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-03-20/fr.html.erb
+++ b/source/blog/posts/2020-03-20/fr.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: behind the scenes
 title: Behind the Scenes
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-03-20/it.html.erb
+++ b/source/blog/posts/2020-03-20/it.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: behind the scenes
 title: Dietro le quinte
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-04-11/de.html.erb
+++ b/source/blog/posts/2020-04-11/de.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: stronger together
 title: Gemeinsam sind wir stark
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-04-11/en.html.erb
+++ b/source/blog/posts/2020-04-11/en.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: stronger together
 title: Stronger together
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-04-11/fr.html.erb
+++ b/source/blog/posts/2020-04-11/fr.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: stronger together
 title: Stronger together
 author: Andre Kahles
 ---

--- a/source/blog/posts/2020-04-11/it.html.erb
+++ b/source/blog/posts/2020-04-11/it.html.erb
@@ -1,4 +1,5 @@
 ---
+permalink: stronger together
 title: Insieme siamo più forti
 author: Andre Kahles
 ---


### PR DESCRIPTION
Adds permalink field to blog posts and makes it part of the URL, so that it's compatible with our JS language redirection code.

When creating a new blog post, be sure to add a `permalink` field to the front matter that's the same across all languages. For example, the header for the first blog post looks like this for German:
```
---
permalink: behind the scenes
title: Hinter den Kulissen
author: Andre Kahles
---
```

Compared to this for Italian:
```
---
permalink: behind the scenes
title: Dietro le quinte
author: Andre Kahles
---
```

We might want to come to a consensus on which language to use for the permalink. I've used English, but we can use something else (German, perhaps, since it's the default for the site).