### PR TITLE
Language redirect JS code now preserves the entire path

### DIFF
--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -62,12 +62,22 @@ function goToLang(lang) {
     return;
   }
 
-  var path = normPath.split("/").pop();
-  if (lang === 'de') {
-    window.location.assign(window.location.origin + '/' + path);
+  var isBlogPost = normPath.indexOf("blog/posts") !== -1;
+  var pathParts = normPath.split("/");
+
+  if (pathParts[0] === 'en' || pathParts[0] === 'fr' || pathParts[0] === 'it' || pathParts[0] === 'de') {
+    // remove the language prefix
+    pathParts.shift();
+  }
+
+  if (lang === 'de' && !isBlogPost) {
+    // for german, non-blog URLs always omit the language code
+    window.location.assign(window.location.origin + '/' + pathParts.join("/"));
   }
   else {
-    window.location.assign(window.location.origin + '/' + lang + '/' + path);
+    // non-de paths always have the language code prefix
+    // additionally, blog posts are *always* prefixed with their language code, unlike the rest of the site
+    window.location.assign(window.location.origin + '/' + lang + '/' + pathParts.join("/"));
   }
 }
 


### PR DESCRIPTION
Prior to this PR, the language redirect code would remove only the last element of the path and prepend the new language code to that. This works fine for the majority of the site since nothing is nested, but the blog post URLs contain `blog`, `posts`, the date, and the title as a series of subdirectories.

This PR modifies the language redirect code to remove only the language prefix, if present, then reconstitute the entire path with the chosen language code prepended to it. It contains special handling for blog posts, since the language code is always present in those URLs.